### PR TITLE
force candidates field to int

### DIFF
--- a/lib/WebService/SmartyStreets.pm
+++ b/lib/WebService/SmartyStreets.pm
@@ -39,7 +39,7 @@ method verify_address(
         city       => $city,
         state      => $state,
         zipcode    => $zipcode,
-        candidates => $candidates,
+        candidates => int($candidates),
     }]);
 
     AddressNotFound->throw unless $results and @$results;


### PR DESCRIPTION
A `$candidates` that is passed in with a value such as `"2"` will pass the
`Int` type constraint, but will get encoded to a json string and cause
SmartyStrees to respond with a 400 "Bad Request (Malformed Payload)".
